### PR TITLE
Use data- attribute instead of #hash to pass resource uid

### DIFF
--- a/lib/Plack/App/Debugger.pm
+++ b/lib/Plack/App/Debugger.pm
@@ -77,7 +77,7 @@ sub make_injector_middleware {
         my $env = shift;
         die "Unable to locate the debugger request-uid, cannot inject the debugger application"
             unless exists $env->{'plack.debugger.request_uid'};
-        sprintf '<script id="plack-debugger-js-init" type="text/javascript" src="%s#%s"></script>' => ( 
+        sprintf '<script id="plack-debugger-js-init" type="text/javascript" src="%s" data-uid="%s"></script>' => ( 
             $js_url, 
             $env->{'plack.debugger.request_uid'} 
         );

--- a/share/js/plack-debugger.js
+++ b/share/js/plack-debugger.js
@@ -16,13 +16,13 @@ Plack.Debugger.MAX_RETRIES              = 5;
 Plack.Debugger.RETRY_BACKOFF_MULTIPLIER = 1000;
 
 Plack.Debugger.prototype._init_config = function () {
-    var init_url = document.getElementById('plack-debugger-js-init').src;
+    var script = document.getElementById('plack-debugger-js-init');
 
     var config = {
-        'current_request_uid' : init_url.split("#")[1]
+        'current_request_uid' : script.getAttribute('data-uid')
     };
 
-    var url_parts = init_url.split('/'); 
+    var url_parts = script.src.split('/');
     url_parts.pop(); config.static_js_url = url_parts.join('/');
     url_parts.pop(); config.static_url    = url_parts.join('/');
     url_parts.pop(); config.root_url      = url_parts.join('/');


### PR DESCRIPTION
Fixes weird case where Chrome loads the script twice + introduces a cleaner way to set init parameters.
